### PR TITLE
Remove unneeded "exe = true;"

### DIFF
--- a/JOSM/scripts/combine-highways/index.js
+++ b/JOSM/scripts/combine-highways/index.js
@@ -174,7 +174,6 @@ while (exe) {
     ways();
     merge();
     if (interways.length > 0) {
-        exe = true;
         interways = [];
         interways_id = {};
         endnodes = [];


### PR DESCRIPTION
Unless I really need coffee here, `exe` already has a `true` value and thus it's unneeded to reassign it here.