### PR TITLE
Add canonical link

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,7 @@
   <meta http-equiv='content-type' content='text/html; charset=utf-8' />
   <meta charset='UTF-8'/>
   <meta http-equiv='X-UA-Compatible' content='IE=edge' />
+  <link rel="canonical" href="https://labs.mapbox.com/mapping{{page.url}}" >
   <meta name='robots' content='{% if page.hidden %}noindex{% else %}index{% endif %}'/>
   <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
   <meta name='apple-mobile-web-app-capable' content='yes' />


### PR DESCRIPTION
This PR adds a canonical link to help search engines discern between duplicates and the original labs.mapbox.com/mapping .


Related https://github.com/mapbox/mapping/issues/362

@mikelmaron or @katydecorah for review, please. 